### PR TITLE
Fix badges and document publishing workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Targets **minimal, unique** puzzles (17-clue hunt capable).
 
 > © 2025 Stamatis-Christos Saridakis — MIT. Core algorithm: exact cover (Knuth). This implementation is original and bitset-based.
 
-[![CI](https://github.com/#SaridakisStamatisChristos/sudoku-dlx-bitset/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-username>/sudoku-dlx/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/SaridakisStamatisChristos/sudoku-dlx-bitset/branch/main/graph/badge.svg)](https://codecov.io/gh/<your-username>/sudoku_dlx)
-[![PyPI version](https://img.shields.io/pypi/v/sudoku_dlx-bitset.svg)](https://pypi.org/project/sudoku_dlx/)
-[![pages](https://img.shields.io/badge/GitHubPages-demo-blue)](https://sudoku_dlx.github.io/sudoku-dlx)
+[![CI](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx/branch/main/graph/badge.svg)](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx)
+[![License: MIT](https://img.shields.io/github/license/SaridakisStamatisChristos/sudoku_dlx.svg)](LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/sudoku-dlx-bitset.svg)](https://pypi.org/project/sudoku-dlx-bitset/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-demo-blue)](https://SaridakisStamatisChristos.github.io/sudoku_dlx/)
 
 ## Features
 - Bitset DLX (no pointer structs), precomputed 729×324 exact-cover matrix
@@ -78,3 +79,27 @@ print(hardness_estimate(g))  # e.g., 3.8
 ## License
 
 MIT — see LICENSE.
+
+## Publish to PyPI
+
+This repository is already structured as a Python package (`src` layout, metadata in `pyproject.toml`).
+To publish a new version on [PyPI](https://pypi.org/project/sudoku-dlx-bitset/):
+
+1. Update `pyproject.toml` with the new `version` and adjust the changelog/release notes.
+2. Make sure the build backend is installed, then build the distribution artifacts:
+
+   ```bash
+   python -m pip install --upgrade build twine
+   python -m build  # creates dist/*.tar.gz and dist/*.whl
+   ```
+
+3. Upload the artifacts with [Twine](https://twine.readthedocs.io/):
+
+   ```bash
+   python -m twine upload dist/*
+   ```
+
+4. Tag the release in Git and push the tag so GitHub releases stay in sync.
+
+The CI workflow already runs tests against multiple Python versions and uploads coverage
+reports to Codecov; the `pages` workflow deploys the static demo from the `web/` directory.


### PR DESCRIPTION
## Summary
- update README badges to point at the repository and add an MIT license badge
- document the steps required to publish the project to PyPI
- configure the GitHub Pages workflow with the recommended configure-pages step

## Testing
- not run (package dependencies could not be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1115b0afc83338c245ce274f98b7f