### PR TITLE
Add module entry point for CLI execution

### DIFF
--- a/src/sudoku_dlx/__main__.py
+++ b/src/sudoku_dlx/__main__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a __main__ module that reuses the existing CLI entry point so `python -m sudoku_dlx` works

## Testing
- PYTHONPATH=src pytest -o addopts="" tests/test_cli.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e1451b1e108333a4dfde61ea38d0ac