### PR TITLE
Fix license badge repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Targets **minimal, unique** puzzles (17-clue hunt capable).
 
 [![CI](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx/branch/main/graph/badge.svg)](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx)
-[![License: MIT](https://img.shields.io/github/license/SaridakisStamatisChristos/sudoku_dlx.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/github/license/SaridakisStamatisChristos/sudoku-dlx-bitset.svg)](LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/sudoku-dlx-bitset.svg)](https://pypi.org/project/sudoku-dlx-bitset/)
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-demo-blue)](https://SaridakisStamatisChristos.github.io/sudoku_dlx/)
 


### PR DESCRIPTION
## Summary
- fix the license badge to reference the sudoku-dlx-bitset repository slug

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e14aca24b883338cfdf222abcee8c1