### PR TITLE
Include py.typed in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,13 @@ Changelog = "https://github.com/SaridakisStamatisChristos/sudoku_dlx/releases"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+sudoku_dlx = ["py.typed"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Summary
- enable setuptools to include package data when building
targets
- ensure the py.typed marker is included in distributions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14e81d63c8333a6576a5080827778