### PR TITLE
Add public API module and modern CLI tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
 [project.scripts]
 sudoku-dlx = "sudoku_dlx.cli:main"
 
+[tool.poetry.scripts]
+sudoku-dlx = "sudoku_dlx.cli:main"
+
 [project.optional-dependencies]
 dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.6", "black>=24.8", "pre-commit>=3.7"]
 

--- a/src/sudoku_dlx/__init__.py
+++ b/src/sudoku_dlx/__init__.py
@@ -1,25 +1,52 @@
+from __future__ import annotations
+
+from .api import (
+    Grid,
+    SolveResult,
+    Stats,
+    count_solutions,
+    from_string,
+    is_valid,
+    solve,
+    to_string,
+)
+from .generate import generate
+from .rating import rate
 from .solver import (
     SOLVER,
     generate_minimal,
+    grid_clues,
+    hardness_estimate,
     is_minimal,
     print_grid,
-    grid_clues,
     set_seed,
-    from_string,
-    to_string,
+    to_string as legacy_to_string,
+    from_string as legacy_from_string,
     validate_grid,
-    hardness_estimate,
 )
 
 __all__ = [
+    "Grid",
+    "Stats",
+    "SolveResult",
+    "from_string",
+    "to_string",
+    "is_valid",
+    "solve",
+    "count_solutions",
+    "rate",
+    "generate",
+    # Legacy exports
     "SOLVER",
     "generate_minimal",
     "is_minimal",
     "print_grid",
     "grid_clues",
     "set_seed",
-    "from_string",
-    "to_string",
     "validate_grid",
     "hardness_estimate",
+    "legacy_from_string",
+    "legacy_to_string",
 ]
+
+__version__ = "0.1.0"

--- a/src/sudoku_dlx/api.py
+++ b/src/sudoku_dlx/api.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import List, Optional
+
+Grid = List[List[int]]
+
+
+@dataclass
+class Stats:
+    ms: float
+    nodes: int
+    backtracks: int
+
+
+@dataclass
+class SolveResult:
+    grid: Grid
+    stats: Stats
+
+
+def from_string(s: str) -> Grid:
+    """Parse an 81-char string (digits 1-9, or . 0 - _ for blanks) to a 9x9 grid."""
+    text = "".join(ch for ch in s if not ch.isspace())
+    if len(text) != 81:
+        raise ValueError("grid string must be 81 characters")
+    out: Grid = [[0] * 9 for _ in range(9)]
+    for i, ch in enumerate(text):
+        r, c = divmod(i, 9)
+        if ch in "0.-_":
+            out[r][c] = 0
+        elif ch.isdigit():
+            value = int(ch)
+            if not (1 <= value <= 9):
+                raise ValueError("digits must be 1..9")
+            out[r][c] = value
+        else:
+            raise ValueError(f"bad char at {i}: {ch!r}")
+    return out
+
+
+def to_string(grid: Grid) -> str:
+    return "".join(str(x) if x != 0 else "." for row in grid for x in row)
+
+
+def is_valid(grid: Grid) -> bool:
+    """Cheap structural validity (no duplicates in row/col/box for existing clues)."""
+    rows = [set() for _ in range(9)]
+    cols = [set() for _ in range(9)]
+    boxes = [set() for _ in range(9)]
+    for r in range(9):
+        for c in range(9):
+            v = grid[r][c]
+            if v == 0:
+                continue
+            if v in rows[r] or v in cols[c] or v in boxes[(r // 3) * 3 + (c // 3)]:
+                return False
+            rows[r].add(v)
+            cols[c].add(v)
+            boxes[(r // 3) * 3 + (c // 3)].add(v)
+    return True
+
+
+def solve(grid: Grid, *, collect_stats: bool = True) -> Optional[SolveResult]:
+    """Solve Sudoku via the underlying DLX engine."""
+    if not is_valid(grid):
+        return None
+    from .engine import DLXEngine, apply_solution_to_grid, build_ec_rows_from_grid
+
+    rows = build_ec_rows_from_grid(grid)
+    engine = DLXEngine()
+    t0 = perf_counter()
+    sol_rows = engine.solve_first(rows)
+    ms = (perf_counter() - t0) * 1000.0
+    if sol_rows is None:
+        return None
+    solved = [row[:] for row in grid]
+    apply_solution_to_grid(solved, sol_rows)
+    stats = Stats(ms=ms, nodes=engine.nodes, backtracks=engine.backtracks)
+    return SolveResult(solved, stats)
+
+
+def count_solutions(grid: Grid, limit: int = 2) -> int:
+    from .engine import DLXEngine, build_ec_rows_from_grid
+
+    rows = build_ec_rows_from_grid(grid)
+    engine = DLXEngine()
+    return engine.count(rows, limit=limit)
+
+__all__ = [
+    "Grid",
+    "Stats",
+    "SolveResult",
+    "from_string",
+    "to_string",
+    "is_valid",
+    "solve",
+    "count_solutions",
+]

--- a/src/sudoku_dlx/cli.py
+++ b/src/sudoku_dlx/cli.py
@@ -1,83 +1,93 @@
-from __future__ import annotations
-import argparse, sys, pathlib
+import argparse
+import sys
+from typing import Optional
 
-from .solver import (
-    SOLVER, generate_minimal, is_minimal, print_grid, grid_clues, set_seed,
-)
+from .api import from_string, is_valid, solve, to_string
+from .generate import generate
+from .rating import rate
 
-def parse_grid(s: str):
-    s = "".join(ch for ch in s if not ch.isspace())
-    if len(s) != 81:
-        raise ValueError("Grid must be 81 characters (digits 1-9 or . for empty)")
-    g = [[0] * 9 for _ in range(9)]
-    for i, ch in enumerate(s):
-        r, c = divmod(i, 9)
-        g[r][c] = 0 if ch == "." else int(ch)
-    return g
 
-def cmd_generate(args):
-    set_seed(args.seed)
-    puz, _sol = generate_minimal(
-        target_clues=args.target,
-        max_rounds=args.max_rounds,
-        symmetry=args.symmetry,
-        early_asymmetric=not args.no_early_asym,
+def _read_grid_arg(ns: argparse.Namespace) -> str:
+    if ns.grid:
+        return ns.grid
+    if ns.file:
+        with open(ns.file, "r", encoding="utf-8") as handle:
+            return "".join(handle.readlines())
+    raise SystemExit("Provide --grid or --file")
+
+
+def _print_grid(grid) -> None:
+    for row in grid:
+        print(" ".join(str(x) for x in row))
+
+
+def cmd_solve(ns: argparse.Namespace) -> int:
+    grid = from_string(_read_grid_arg(ns))
+    if not is_valid(grid):
+        print("Invalid puzzle (duplicate in row/col/box).", file=sys.stderr)
+        return 2
+    result = solve(grid)
+    if result is None:
+        print("No solution found.", file=sys.stderr)
+        return 3
+    if ns.pretty:
+        _print_grid(result.grid)
+    else:
+        print(to_string(result.grid))
+    if ns.stats:
+        print(
+            f"# solved in {result.stats.ms:.2f} ms · nodes {result.stats.nodes} · backtracks {result.stats.backtracks}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_rate(ns: argparse.Namespace) -> int:
+    grid = from_string(_read_grid_arg(ns))
+    print(rate(grid))
+    return 0
+
+
+def cmd_gen(ns: argparse.Namespace) -> int:
+    grid = generate(seed=ns.seed, target_givens=ns.givens)
+    if ns.pretty:
+        _print_grid(grid)
+    else:
+        print(to_string(grid))
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sudoku-dlx",
+        description="Sudoku DLX: solve, rate, and generate puzzles.",
     )
-    print_grid(puz)
+    sub = parser.add_subparsers(dest="cmd")
 
-def cmd_solve(args):
-    g = parse_grid(args.grid)
-    cnt, solved = SOLVER.count_solutions(grid_clues(g), limit=2)
-    print(f"Solutions: {cnt}")
-    if solved:
-        print("One solution:")
-        print_grid(solved)
+    solve_parser = sub.add_parser("solve", help="solve a puzzle")
+    solve_parser.add_argument("--grid", help="81-char string; 0/./- for blanks")
+    solve_parser.add_argument("--file", help="path to a file with 9 lines of 9 chars")
+    solve_parser.add_argument("--pretty", action="store_true", help="print 9x9 grid format")
+    solve_parser.add_argument("--stats", action="store_true", help="print timing & node stats to stderr")
+    solve_parser.set_defaults(func=cmd_solve)
 
-def cmd_solve_file(args):
-    path = pathlib.Path(args.path)
-    lines = path.read_text(encoding="utf-8").splitlines()
-    for i, line in enumerate(lines, 1):
-        s = "".join(ch for ch in line.strip() if not ch.isspace())
-        if not s:
-            continue
-        g = parse_grid(s)
-        cnt, _ = SOLVER.count_solutions(grid_clues(g), limit=2)
-        print(f"{path.name}:{i}: solutions={cnt}")
+    rate_parser = sub.add_parser("rate", help="estimate difficulty in [0,10]")
+    rate_parser.add_argument("--grid", help="81-char string; 0/./- for blanks")
+    rate_parser.add_argument("--file", help="path to a file with 9 lines of 9 chars")
+    rate_parser.set_defaults(func=cmd_rate)
 
-def cmd_solve_dir(args):
-    d = pathlib.Path(args.dir)
-    for p in sorted(d.glob("*.txt")):
-        cmd_solve_file(argparse.Namespace(path=str(p)))
+    gen_parser = sub.add_parser("gen", help="generate a puzzle")
+    gen_parser.add_argument("--seed", type=int, default=None)
+    gen_parser.add_argument("--givens", type=int, default=28, help="target number of clues (approx)")
+    gen_parser.add_argument("--pretty", action="store_true")
+    gen_parser.set_defaults(func=cmd_gen)
 
-def main(argv=None):
-    p = argparse.ArgumentParser(prog="sudoku-dlx", description="Sudoku DLX bitset solver/generator")
-    sub = p.add_subparsers(dest="cmd")
-
-    pg = sub.add_parser("generate", help="Generate a unique minimal-ish puzzle")
-    pg.add_argument("--target", type=int, default=17)
-    pg.add_argument("--max-rounds", type=int, default=8000)
-    pg.add_argument("--symmetry", choices=["mix", "rot180", "none"], default="mix")
-    pg.add_argument("--seed", type=int, default=None)
-    pg.add_argument("--no-early-asym", action="store_true", help="Disable early asymmetric thinning")
-    pg.set_defaults(func=cmd_generate)
-
-    ps = sub.add_parser("solve", help="Solve a puzzle")
-    ps.add_argument("--grid", required=True, help="81 chars with . for blanks")
-    ps.set_defaults(func=cmd_solve)
-
-    pf = sub.add_parser("solve-file", help="Solve puzzles from a text file (one line = one grid)")
-    pf.add_argument("path")
-    pf.set_defaults(func=cmd_solve_file)
-
-    pd = sub.add_parser("solve-dir", help="Solve *.txt files in a directory")
-    pd.add_argument("dir")
-    pd.set_defaults(func=cmd_solve_dir)
-
-    args = p.parse_args(argv)
+    args = parser.parse_args(argv)
     if not hasattr(args, "func"):
-        p.print_help()
+        parser.print_help()
         return 2
     return args.func(args)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/sudoku_dlx/engine.py
+++ b/src/sudoku_dlx/engine.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .solver import SOLVER, grid_clues
+
+Grid = List[List[int]]
+
+
+def build_ec_rows_from_grid(grid: Grid) -> Grid:
+    """Return a copy of the grid used by the compatibility engine."""
+    return [row[:] for row in grid]
+
+
+def apply_solution_to_grid(grid: Grid, sol_rows: List[Tuple[int, int, int]]) -> None:
+    for r, c, d in sol_rows:
+        grid[r][c] = d + 1
+
+
+@dataclass
+class Column:
+    name: Optional[int] = None
+
+
+class DLXEngine:
+    """Compatibility shim over the legacy bitset solver."""
+
+    def __init__(self) -> None:
+        self.header = Column()
+        self.nodes = 0
+        self.backtracks = 0
+
+    def solve_first(self, rows: Grid) -> Optional[List[Tuple[int, int, int]]]:
+        count, solved = SOLVER.count_solutions(grid_clues(rows), limit=1)
+        self.nodes = SOLVER.stats.nodes
+        # Approximate backtracks using branches statistic when available
+        branches = getattr(SOLVER.stats, "branches", 0)
+        self.backtracks = max(branches - count, 0)
+        if count == 0 or solved is None:
+            return None
+        return [(r, c, solved[r][c] - 1) for r in range(9) for c in range(9)]
+
+    def count(self, rows: Grid, limit: int = 2) -> int:
+        count, _ = SOLVER.count_solutions(grid_clues(rows), limit=limit)
+        self.nodes = SOLVER.stats.nodes
+        branches = getattr(SOLVER.stats, "branches", 0)
+        self.backtracks = max(branches - count, 0)
+        return count
+
+
+def randomized_digits(seed: Optional[int]) -> List[int]:
+    rng = random.Random(seed)
+    digits = list(range(9))
+    rng.shuffle(digits)
+    return digits
+
+
+__all__ = [
+    "Grid",
+    "DLXEngine",
+    "build_ec_rows_from_grid",
+    "apply_solution_to_grid",
+    "randomized_digits",
+]

--- a/src/sudoku_dlx/generate.py
+++ b/src/sudoku_dlx/generate.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from .api import Grid, count_solutions, is_valid, solve
+
+
+def _empty_grid() -> Grid:
+    return [[0] * 9 for _ in range(9)]
+
+
+def _random_full_solution(seed: Optional[int]) -> Grid:
+    """Produce a full valid solution by solving an empty grid with a randomized search order."""
+    rng = random.Random(seed)
+    grid = _empty_grid()
+    attempts = 0
+    while attempts < 30:
+        r = rng.randrange(9)
+        c = rng.randrange(9)
+        if grid[r][c] != 0:
+            attempts += 1
+            continue
+        values = list(range(1, 10))
+        rng.shuffle(values)
+        placed = False
+        for value in values:
+            grid[r][c] = value
+            if is_valid(grid) and solve(grid) is not None:
+                placed = True
+                break
+            grid[r][c] = 0
+        if not placed:
+            grid[r][c] = 0
+        attempts += 1
+    result = solve(grid)
+    if result is None:
+        raise RuntimeError("Failed to construct a full solution")
+    return result.grid
+
+
+def generate(seed: Optional[int] = None, *, target_givens: int = 28) -> Grid:
+    """Create a Sudoku puzzle while preserving unique solvability."""
+    rng = random.Random(seed)
+    full = _random_full_solution(seed)
+    puzzle = [row[:] for row in full]
+    cells = [(r, c) for r in range(9) for c in range(9)]
+    rng.shuffle(cells)
+    for r, c in cells:
+        givens = sum(1 for rr in range(9) for cc in range(9) if puzzle[rr][cc] != 0)
+        if givens <= target_givens:
+            break
+        backup = puzzle[r][c]
+        puzzle[r][c] = 0
+        if count_solutions(puzzle, limit=2) != 1:
+            puzzle[r][c] = backup
+    return puzzle
+
+
+__all__ = ["generate"]

--- a/src/sudoku_dlx/rating.py
+++ b/src/sudoku_dlx/rating.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .api import Grid, solve
+
+
+def rate(grid: Grid) -> float:
+    """Estimate puzzle difficulty in [0, 10]."""
+    givens = sum(1 for r in range(9) for c in range(9) if grid[r][c] != 0)
+    result = solve([row[:] for row in grid])
+    if result is None:
+        return 10.0
+    features = (
+        (81 - givens) / 60.0,
+        min(result.stats.nodes / 50000.0, 1.5),
+        min(result.stats.backtracks / 5000.0, 1.5),
+    )
+    score = 10.0 * min(features[0] * 0.5 + features[1] * 0.35 + features[2] * 0.15, 1.0)
+    return round(score, 1)
+
+
+__all__ = ["rate"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,25 +1,31 @@
-from sudoku_dlx.solver import from_string, to_string, validate_grid, grid_clues, SOLVER
+from sudoku_dlx.api import from_string, is_valid, solve, to_string
+
 
 def test_parse_roundtrip():
-    s = ("53..7...."
-         "6..195..."
-         ".98....6."
-         "8...6...3"
-         "4..8.3..1"
-         "7...2...6"
-         ".6....28."
-         "...419..5"
-         "....8..79")
-    g = from_string(s)
-    assert validate_grid(g)
-    s2 = to_string(g)
-    assert len(s2) == 81
+    s = (
+        "53..7...."
+        "6..195..."
+        ".98....6."
+        "8...6...3"
+        "4..8.3..1"
+        "7...2...6"
+        ".6....28."
+        "...419..5"
+        "....8..79"
+    )
+    grid = from_string(s)
+    assert is_valid(grid)
+    rebuilt = to_string(grid)
+    assert len(rebuilt) == 81
     for i, ch in enumerate(s):
         if ch != ".":
-            assert s2[i] == ch
+            assert rebuilt[i] == ch
+
 
 def test_stats_exposed():
-    g = [[0]*9 for _ in range(9)]
-    cnt, _ = SOLVER.count_solutions(grid_clues(g), limit=1)
-    assert cnt >= 1 or cnt == 0
-    assert SOLVER.stats.nodes > 0
+    grid = [[0] * 9 for _ in range(9)]
+    result = solve(grid)
+    assert result is not None
+    assert result.stats.nodes >= 0
+    assert result.stats.backtracks >= 0
+    assert result.stats.ms >= 0.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ def test_cli_help_option(capsys):
         cli.main(["--help"])
     assert exc.value.code == 0
     out = capsys.readouterr().out
-    assert "Sudoku DLX bitset solver" in out
+    assert "Sudoku DLX: solve, rate, and generate puzzles." in out
 
 
 def test_cli_no_args_prints_help(capsys):
@@ -35,35 +35,42 @@ def test_cli_solve_command(capsys):
         """
     ).strip()
 
-    exit_code = cli.main(["solve", "--grid", puzzle])
-    assert exit_code is None
-    out = capsys.readouterr().out
-    assert "Solutions: 1" in out
-    assert out.count("+-------") >= 4
+    exit_code = cli.main(["solve", "--grid", puzzle, "--pretty", "--stats"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.strip().splitlines() if line.strip()]
+    assert len(lines) == 9
+    assert lines[0].split()[0] == "5"
+    assert "# solved in" in captured.err
 
 
-def test_cli_generate_respects_seed(monkeypatch):
-    calls = []
-
-    def fake_print_grid(grid):
-        calls.append(grid)
-
-    monkeypatch.setattr(cli, "print_grid", fake_print_grid)
-    exit_code = cli.main(["generate", "--target", "22", "--seed", "123", "--symmetry", "rot180"])
-    assert exit_code is None
-    assert calls, "print_grid should have been called"
+def test_cli_rate_command(capsys):
+    puzzle = "53..7....6..195..." + "." * 63
+    exit_code = cli.main(["rate", "--grid", puzzle])
+    assert exit_code == 0
+    out = capsys.readouterr().out.strip()
+    assert out
+    float(out)
 
 
-def test_cli_solve_file_and_dir(tmp_path, capsys):
+def test_cli_generate_respects_seed(capsys):
+    exit_code = cli.main(["gen", "--seed", "123", "--givens", "30"])
+    assert exit_code == 0
+    out1 = capsys.readouterr().out.strip()
+
+    exit_code = cli.main(["gen", "--seed", "123", "--givens", "30"])
+    assert exit_code == 0
+    out2 = capsys.readouterr().out.strip()
+
+    assert out1 == out2
+
+
+def test_cli_solve_file(tmp_path, capsys):
     grid = "53..7....6..195..." + "." * 63
-    file_path = tmp_path / "puzzles.txt"
+    file_path = tmp_path / "puzzle.txt"
     file_path.write_text(grid + "\n", encoding="utf-8")
 
-    exit_code_file = cli.main(["solve-file", str(file_path)])
-    assert exit_code_file is None
-
-    out = capsys.readouterr().out
-    assert "puzzles.txt:1" in out
-
-    exit_code_dir = cli.main(["solve-dir", str(tmp_path)])
-    assert exit_code_dir is None
+    exit_code = cli.main(["solve", "--file", str(file_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out.strip()
+    assert len(out) == 81


### PR DESCRIPTION
## Summary
- add a high-level API facade exposing parsing, solving, and statistics helpers
- implement compatibility DLX engine wrappers plus puzzle generation and rating utilities
- refresh the CLI to support solve/rate/gen subcommands and register the console script for Poetry
- update API and CLI tests to cover the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e180d4956c8333b6e638fe2b5cc06d