### PR TITLE
Add CLI dedupe command using canonical form

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ sudoku-dlx rate  --grid "<81chars>"
 sudoku-dlx canon --grid "<81chars>"  # D4 × bands/stacks × inner row/col × digit relabel
 # Produces a stable 81-char string for deduping datasets.
 
+# Dedupe a file of puzzles (fast)
+sudoku-dlx dedupe --in puzzles.txt --out unique.txt
+
 # Generate a unique puzzle (deterministic with seed)
 sudoku-dlx gen   --seed 123 --givens 30           # ~target clue count (approx)
 sudoku-dlx gen   --seed 123 --givens 30 --pretty

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+
+from sudoku_dlx import cli
+
+S = (
+    "53..7...."
+    "6..195..."
+    ".98....6."
+    "8...6...3"
+    "4..8.3..1"
+    "7...2...6"
+    ".6....28."
+    "...419..5"
+    "....8..79"
+)
+
+
+def test_cli_dedupe_makes_unique_file():
+    s180 = "".join(reversed(S))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        infile = os.path.join(tmpdir, "in.txt")
+        outfile = os.path.join(tmpdir, "out.txt")
+        with open(infile, "w", encoding="utf-8") as handle:
+            handle.write(S + "\n")
+            handle.write(s180 + "\n")
+        rc = cli.main(["dedupe", "--in", infile, "--out", outfile])
+        assert rc == 0
+        with open(outfile, "r", encoding="utf-8") as handle:
+            lines = [line.strip() for line in handle if line.strip()]
+        assert len(lines) == 1


### PR DESCRIPTION
## Summary
- add a `dedupe` subcommand that canonicalizes puzzles and writes unique grids
- provide a regression test covering the CLI deduplication workflow
- document the new command in the README quick reference

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e233678de08333843a8cabd5a72b1c