### PR TITLE
Add Pyodide web worker for Sudoku solver

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,13 +24,15 @@
     <button id="sampleBtn" class="secondary">Load Sample</button>
   </div>
   <h3>Log</h3>
-  <div id="log" class="log">Loading Pyodide...</div>
+  <div id="log" class="log">Initializing solver worker...</div>
   <div class="foot">Algorithm: Exact cover (Algorithm X / DLX). Implementation © 2025 Stamatis-Christos Saridakis — MIT.</div>
 
-  <script src="https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js"></script>
   <script>
     const gridEl = document.getElementById('grid');
     const logEl = document.getElementById('log');
+    const solveBtn = document.getElementById('solveBtn');
+    const clearBtn = document.getElementById('clearBtn');
+    const sampleBtn = document.getElementById('sampleBtn');
     function mkCell(){ const i=document.createElement('input'); i.className='cell'; i.maxLength=1; i.pattern='[1-9]'; i.inputMode='numeric'; return i; }
     for(let r=0;r<9;r++){ for(let c=0;c<9;c++){ gridEl.appendChild(mkCell()); }}
 
@@ -44,148 +46,54 @@
       for(let i=0;i<81;i++){ cells[i].value = v[i]?String(v[i]):''; }
     }
 
-    const PYODIDE_INDEX_URL = "https://cdn.jsdelivr.net/pyodide/v0.26.1/full/";
-    let pyodideReady = (async ()=>{
-      try {
-        log("Downloading Pyodide runtime...");
-        const py = await loadPyodide({ indexURL: PYODIDE_INDEX_URL });
-        log("Initializing solver...");
-        await py.loadPackage([]);
-        const code = `
-from typing import List, Tuple
-def col_cell(r, c): return r*9 + c
-def col_row(r, v):  return 81  + r*9 + (v-1)
-def col_col(c, v):  return 162 + c*9 + (v-1)
-def col_box(b, v):  return 243 + b*9 + (v-1)
-def box_of(r, c):   return (r//3)*3 + (c//3)
-ROW_COLS: List[List[int]] = []
-ROW_PAYLOAD: List[Tuple[int,int,int]] = []
-COL_ROWS_BITS: List[int] = [0]*324
-RCV_TO_ROWIDX: dict[Tuple[int,int,int], int] = {}
-def _precompute_matrix():
-    idx = 0
-    for r in range(9):
-        for c in range(9):
-            b = box_of(r, c)
-            for v in range(1,10):
-                cols = [col_cell(r,c), col_row(r,v), col_col(c,v), col_box(b,v)]
-                ROW_COLS.append(cols)
-                ROW_PAYLOAD.append((r,c,v))
-                RCV_TO_ROWIDX[(r,c,v)] = idx
-                mask = 1 << idx
-                for col in cols: COL_ROWS_BITS[col] |= mask
-                idx += 1
-_precompute_matrix()
-ALL_ROWS_MASK = (1 << 729) - 1
-ALL_COLS_MASK = (1 << 324) - 1
-def iter_set_bits(x:int):
-    while x:
-        lsb = x & -x
-        i = (lsb.bit_length()-1)
-        yield i
-        x ^= lsb
-def is_bit_set(x:int,i:int)->bool: return (x>>i)&1
-def clear_bit(x:int,i:int)->int: return x & ~(1<<i)
-class BitDLX:
-    def _choose_col(self, rows_mask:int, cols_mask:int):
-        best_col=None; best_sz=10**9
-        for c in range(324):
-            if not is_bit_set(cols_mask,c): continue
-            cand = COL_ROWS_BITS[c] & rows_mask
-            sz = cand.bit_count()
-            if sz==0: return c
-            if sz<best_sz: best_sz=sz; best_col=c
-            if sz<=1: break
-        return best_col
-    def _cover_row(self, rows_mask:int, cols_mask:int, row_idx:int):
-        cols = ROW_COLS[row_idx]
-        union_rows=0
-        for c in cols: union_rows |= (COL_ROWS_BITS[c] & rows_mask)
-        rows_mask2 = rows_mask & ~union_rows
-        for c in cols: cols_mask = clear_bit(cols_mask, c)
-        return rows_mask2, cols_mask
-    def _search(self, rows_mask:int, cols_mask:int, limit:int, keep_one:bool, collect_sol:list, found:list):
-        if cols_mask==0:
-            found[0]+=1; return found[0]>=limit
-        c = self._choose_col(rows_mask, cols_mask)
-        cand = COL_ROWS_BITS[c] & rows_mask
-        if cand==0: return False
-        for r in iter_set_bits(cand):
-            rows2, cols2 = self._cover_row(rows_mask, cols_mask, r)
-            if keep_one: collect_sol.append(r)
-            if self._search(rows2, cols2, limit, keep_one, collect_sol, found): return True
-            if keep_one: collect_sol.pop()
-        return False
-    def count_solutions(self, clues:list[tuple[int,int,int]], limit:int=2):
-        rows_mask = ALL_ROWS_MASK; cols_mask = ALL_COLS_MASK
-        for (r,c,v) in clues:
-            row_idx = RCV_TO_ROWIDX.get((r,c,v))
-            if row_idx is None or not is_bit_set(rows_mask, row_idx): return 0, None
-            rows_mask, cols_mask = self._cover_row(rows_mask, cols_mask, row_idx)
-        found=[0]; collect=[]
-        self._search(rows_mask, cols_mask, limit, True, collect, found)
-        if found[0]==0: return 0, None
-        grid=[[0]*9 for _ in range(9)]
-        for (rr,cc,vv) in clues: grid[rr][cc]=vv
-        for rid in collect:
-            rr,cc,vv = ROW_PAYLOAD[rid]; grid[rr][cc]=vv
-        return found[0], grid
-SOLVER = BitDLX()
-def parse_linear(vals):
-    g=[[0]*9 for _ in range(9)]
-    for i,v in enumerate(vals):
-        r,c=divmod(i,9); g[r][c]=int(v)
-    return g
-def clues_from_grid(g):
-    return [(r,c,g[r][c]) for r in range(9) for c in range(9) if g[r][c]!=0]
-`;
-        py.runPython(code);
-        log("Pyodide ready. Enter digits and press Solve.");
-        return py;
-      } catch (err) {
-        console.error("Failed to load Pyodide", err);
-        log("Failed to load Pyodide. See console for details.");
-        throw err;
-      }
-    })();
+    const worker = new Worker(new URL('./worker.js', window.location.href), { type: 'classic' });
 
     function log(msg){ logEl.textContent = msg; }
-    document.getElementById('solveBtn').onclick = async ()=>{
-      let py;
-      try {
-        py = await pyodideReady;
-      } catch (err) {
-        log("Pyodide is not available.");
+    function setSolving(flag){ solveBtn.disabled = flag; solveBtn.textContent = flag ? 'Solving…' : 'Solve'; }
+
+    worker.onmessage = (event)=>{
+      const { type } = event.data || {};
+      if (type === 'status') {
+        log(event.data.message);
         return;
       }
-      const v = readGrid();
-      log("Solving...");
-      py.globals.set("vals", v);
-      const out = py.runPython(`
-g = parse_linear(vals)
-cnt, sol = SOLVER.count_solutions(clues_from_grid(g), limit=2)
-cnt, sol
-`);
-      const cnt = out.get(0)
-      const sol = out.get(1)
-      if (cnt == 0){ log("No solution (contradiction)."); return; }
-      if (cnt > 1){ log("Multiple solutions ("+cnt+"). Showing one."); }
-      const js = sol.toJs();
-      const flat = [];
-      for(let r=0;r<9;r++){ for(let c=0;c<9;c++){ flat.push(js[r][c]); } }
-      writeGrid(flat);
-      log("Solved. Solutions="+cnt);
+      if (type === 'result') {
+        setSolving(false);
+        if (event.data.status === 'ok') {
+          const timeMsg = typeof event.data.ms === 'number' ? `${event.data.ms.toFixed(2)} ms` : 'unknown time';
+          if (event.data.solutions > 1) {
+            log(`Multiple solutions (${event.data.solutions}). Showing one. Solved in ${timeMsg}.`);
+          } else {
+            log(`Solved in ${timeMsg}.`);
+          }
+          writeGrid(event.data.grid);
+        } else if (event.data.status === 'none') {
+          log('No solution (contradiction).');
+        }
+        return;
+      }
+      if (type === 'error') {
+        setSolving(false);
+        console.error('Worker error', event.data.detail || event.data.message);
+        log(event.data.message || 'An unexpected error occurred.');
+        return;
+      }
     };
-    document.getElementById('clearBtn').onclick = ()=>{ writeGrid(Array(81).fill(0)); log("Cleared."); };
-    document.getElementById('sampleBtn').onclick = async ()=>{
-      try {
-        await pyodideReady;
-      } catch (err) {
-        log("Cannot load sample because Pyodide failed to initialize.");
-        return;
-      }
+
+    worker.postMessage({ type: 'init' });
+
+    solveBtn.onclick = ()=>{
+      setSolving(true);
+      log('Solving...');
+      const v = readGrid();
+      worker.postMessage({ type: 'solve', values: v });
+    };
+    clearBtn.onclick = ()=>{ writeGrid(Array(81).fill(0)); if (!solveBtn.disabled) { log('Cleared.'); } };
+    sampleBtn.onclick = ()=>{
       const s=("53..7...."+"6..195..."+".98....6."+"8...6...3"+"4..8.3..1"+"7...2...6"+".6....28."+"...419..5"+"....8..79");
-      const arr=[...s].map(ch=> ch==='.'?0:parseInt(ch,10)); writeGrid(arr); log("Loaded sample.");
+      const arr=[...s].map(ch=> ch==='.'?0:parseInt(ch,10));
+      writeGrid(arr);
+      if (!solveBtn.disabled) { log('Loaded sample.'); }
     };
   </script>
 </body>

--- a/web/worker.js
+++ b/web/worker.js
@@ -1,0 +1,186 @@
+const PYODIDE_INDEX_URL = "https://cdn.jsdelivr.net/pyodide/v0.26.1/full/";
+let pyodideReadyPromise = null;
+
+async function loadPyodideOnce() {
+  if (pyodideReadyPromise) {
+    return pyodideReadyPromise;
+  }
+  self.postMessage({ type: 'status', message: 'Downloading Pyodide runtime...' });
+  importScripts(`${PYODIDE_INDEX_URL}pyodide.js`);
+  pyodideReadyPromise = (async () => {
+    const py = await loadPyodide({ indexURL: PYODIDE_INDEX_URL });
+    self.postMessage({ type: 'status', message: 'Initializing solver...' });
+    await py.runPythonAsync(`
+from typing import List, Tuple
+
+def col_cell(r, c): return r*9 + c
+
+def col_row(r, v):  return 81  + r*9 + (v-1)
+
+def col_col(c, v):  return 162 + c*9 + (v-1)
+
+def col_box(b, v):  return 243 + b*9 + (v-1)
+
+def box_of(r, c):   return (r//3)*3 + (c//3)
+
+ROW_COLS: List[List[int]] = []
+ROW_PAYLOAD: List[Tuple[int,int,int]] = []
+COL_ROWS_BITS: List[int] = [0]*324
+RCV_TO_ROWIDX: dict[Tuple[int,int,int], int] = {}
+
+def _precompute_matrix():
+    idx = 0
+    for r in range(9):
+        for c in range(9):
+            b = box_of(r, c)
+            for v in range(1,10):
+                cols = [col_cell(r,c), col_row(r,v), col_col(c,v), col_box(b,v)]
+                ROW_COLS.append(cols)
+                ROW_PAYLOAD.append((r,c,v))
+                RCV_TO_ROWIDX[(r,c,v)] = idx
+                mask = 1 << idx
+                for col in cols: COL_ROWS_BITS[col] |= mask
+                idx += 1
+
+_precompute_matrix()
+ALL_ROWS_MASK = (1 << 729) - 1
+ALL_COLS_MASK = (1 << 324) - 1
+
+def iter_set_bits(x:int):
+    while x:
+        lsb = x & -x
+        i = (lsb.bit_length()-1)
+        yield i
+        x ^= lsb
+
+def is_bit_set(x:int,i:int)->bool: return (x>>i)&1
+
+def clear_bit(x:int,i:int)->int: return x & ~(1<<i)
+
+class BitDLX:
+    def _choose_col(self, rows_mask:int, cols_mask:int):
+        best_col=None; best_sz=10**9
+        for c in range(324):
+            if not is_bit_set(cols_mask,c): continue
+            cand = COL_ROWS_BITS[c] & rows_mask
+            sz = cand.bit_count()
+            if sz==0: return c
+            if sz<best_sz: best_sz=sz; best_col=c
+            if sz<=1: break
+        return best_col
+
+    def _cover_row(self, rows_mask:int, cols_mask:int, row_idx:int):
+        cols = ROW_COLS[row_idx]
+        union_rows=0
+        for c in cols: union_rows |= (COL_ROWS_BITS[c] & rows_mask)
+        rows_mask2 = rows_mask & ~union_rows
+        for c in cols: cols_mask = clear_bit(cols_mask, c)
+        return rows_mask2, cols_mask
+
+    def _search(self, rows_mask:int, cols_mask:int, limit:int, keep_one:bool, collect_sol:list, found:list):
+        if cols_mask==0:
+            found[0]+=1; return found[0]>=limit
+        c = self._choose_col(rows_mask, cols_mask)
+        cand = COL_ROWS_BITS[c] & rows_mask
+        if cand==0: return False
+        for r in iter_set_bits(cand):
+            rows2, cols2 = self._cover_row(rows_mask, cols_mask, r)
+            if keep_one: collect_sol.append(r)
+            if self._search(rows2, cols2, limit, keep_one, collect_sol, found): return True
+            if keep_one: collect_sol.pop()
+        return False
+
+    def count_solutions(self, clues:list[tuple[int,int,int]], limit:int=2):
+        rows_mask = ALL_ROWS_MASK; cols_mask = ALL_COLS_MASK
+        for (r,c,v) in clues:
+            row_idx = RCV_TO_ROWIDX.get((r,c,v))
+            if row_idx is None or not is_bit_set(rows_mask, row_idx): return 0, None
+            rows_mask, cols_mask = self._cover_row(rows_mask, cols_mask, row_idx)
+        found=[0]; collect=[]
+        self._search(rows_mask, cols_mask, limit, True, collect, found)
+        if found[0]==0: return 0, None
+        grid=[[0]*9 for _ in range(9)]
+        for (rr,cc,vv) in clues: grid[rr][cc]=vv
+        for rid in collect:
+            rr,cc,vv = ROW_PAYLOAD[rid]; grid[rr][cc]=vv
+        return found[0], grid
+
+SOLVER = BitDLX()
+
+def parse_linear(vals):
+    g=[[0]*9 for _ in range(9)]
+    for i,v in enumerate(vals):
+        r,c=divmod(i,9); g[r][c]=int(v)
+    return g
+
+def clues_from_grid(g):
+    return [(r,c,g[r][c]) for r in range(9) for c in range(9) if g[r][c]!=0]
+    `);
+    self.postMessage({ type: 'status', message: 'Pyodide ready. Enter digits and press Solve.' });
+    return py;
+  })();
+  try {
+    return await pyodideReadyPromise;
+  } catch (err) {
+    pyodideReadyPromise = null;
+    throw err;
+  }
+}
+
+self.onmessage = async (event) => {
+  const { type } = event.data || {};
+  if (type === 'init') {
+    try {
+      await loadPyodideOnce();
+    } catch (err) {
+      self.postMessage({ type: 'error', message: 'Failed to initialize Pyodide.', detail: `${err}` });
+    }
+    return;
+  }
+  if (type === 'solve') {
+    const { values } = event.data;
+    const started = performance.now();
+    let py;
+    try {
+      py = await loadPyodideOnce();
+    } catch (err) {
+      self.postMessage({ type: 'error', message: 'Pyodide is not available.', detail: `${err}` });
+      return;
+    }
+    try {
+      py.globals.set('vals', values);
+      const out = py.runPython(`
+g = parse_linear(vals)
+cnt, sol = SOLVER.count_solutions(clues_from_grid(g), limit=2)
+cnt, sol
+`);
+      const cnt = out.get(0);
+      const sol = out.get(1);
+      let flat = null;
+      if (typeof cnt === 'number' && cnt > 0 && sol !== undefined && sol !== null) {
+        const js = sol.toJs({ create_proxies: false });
+        flat = [];
+        for (let r = 0; r < 9; r++) {
+          for (let c = 0; c < 9; c++) {
+            flat.push(js[r][c]);
+          }
+        }
+      }
+      if (typeof cnt === 'number' && cnt > 0 && Array.isArray(flat)) {
+        const elapsed = performance.now() - started;
+        self.postMessage({ type: 'result', status: 'ok', solutions: cnt, grid: flat, ms: elapsed });
+      } else if (typeof cnt === 'number' && cnt === 0) {
+        self.postMessage({ type: 'result', status: 'none' });
+      } else {
+        self.postMessage({ type: 'error', message: 'Unexpected solver output.' });
+      }
+      if (sol && typeof sol.destroy === 'function') {
+        sol.destroy();
+      }
+      out.destroy();
+    } catch (err) {
+      self.postMessage({ type: 'error', message: 'Solver execution failed.', detail: `${err}` });
+    }
+    return;
+  }
+};


### PR DESCRIPTION
## Summary
- move the in-browser Sudoku solver into a dedicated web worker
- initialize Pyodide inside the worker and post progress and results back to the UI
- update the main page script to interact with the worker and keep the UI responsive during solves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e246cfca788333b267e20ca885e76a