### PR TITLE
Add batch puzzle tools and benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ sudoku-dlx rate  --grid "<81chars>"
 sudoku-dlx canon --grid "<81chars>"  # D4 × bands/stacks × inner row/col × digit relabel
 # Produces a stable 81-char string for deduping datasets.
 
+# Batch tools
+sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 --symmetry rot180 --minimal
+sudoku-dlx rate-file --in puzzles.txt --csv ratings.csv
+python bench/bench_file.py --in puzzles.txt
+
 # Dedupe a file of puzzles (fast)
 sudoku-dlx dedupe --in puzzles.txt --out unique.txt
 

--- a/bench/bench_file.py
+++ b/bench/bench_file.py
@@ -1,0 +1,40 @@
+import argparse
+import statistics as st
+import sys
+import time
+
+from sudoku_dlx import from_string, solve
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark solve() on a file of puzzles (81-chars per line)."
+    )
+    parser.add_argument("--in", dest="in_path", required=True)
+    ns = parser.parse_args()
+
+    times: list[float] = []
+    solved = 0
+    with open(ns.in_path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            s = "".join(ch for ch in line.strip() if not ch.isspace())
+            if not s:
+                continue
+            grid = from_string(s)
+            t0 = time.perf_counter()
+            result = solve(grid)
+            if result is None:
+                continue
+            times.append((time.perf_counter() - t0) * 1000)
+            solved += 1
+    if not times:
+        print("no puzzles measured", file=sys.stderr)
+        return 2
+    mean = st.mean(times)
+    p95 = st.quantiles(times, n=20)[-1]
+    print(f"# puzzles: {solved} · mean {mean:.2f} ms · p95 {p95:.2f} ms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_batch_tools.py
+++ b/tests/test_batch_tools.py
@@ -1,0 +1,24 @@
+from sudoku_dlx import cli
+
+
+def test_gen_batch_and_rate_file(tmp_path):
+    out = tmp_path / "puzzles.txt"
+    rc = cli.main(
+        [
+            "gen-batch",
+            "--out",
+            str(out),
+            "--count",
+            "5",
+            "--givens",
+            "35",
+            "--symmetry",
+            "none",
+        ]
+    )
+    assert rc == 0
+    assert out.exists()
+    lines = [ln.strip() for ln in out.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 5
+    rc = cli.main(["rate-file", "--in", str(out)])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- add CLI commands to generate batches of unique puzzles and rate puzzle files
- provide a benchmark script for measuring solver performance on puzzle lists
- cover the new batch workflow with documentation and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e24e2dc3388333b376df09e490b149