### PR TITLE
Add release and manual publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        type: choice
+        options: ["pypi", "testpypi"]
+        default: "pypi"
+      ref:
+        description: "Git ref to publish (tag or branch). Leave blank to use default branch."
+        required: false
+        default: ""
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || '' }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.target == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload --repository-url https://test.pypi.org/legacy/ --non-interactive dist/*
+
+      - name: Publish to PyPI
+        if: ${{ inputs.target == 'pypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload --non-interactive dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,66 @@
 name: release
+
 on:
   push:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-
 jobs:
-  build-and-publish:
+  build-attach:
+    name: Build package, test, attach to GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # to create GitHub Release & upload assets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build & dev deps
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+      - name: Create/Update GitHub Release with artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-matrix:
+    name: Test (3.10–3.12)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - run: python -m pip install -U pip build
-      - run: python -m build
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          python-version: ${{ matrix.python-version }}
+      - name: Install package (dev)
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -130,3 +130,19 @@ To publish a new version on [PyPI](https://pypi.org/project/sudoku_dlx/):
 
 The CI workflow already runs tests against multiple Python versions and uploads coverage
 reports to Codecov; the `pages` workflow deploys the static demo from the `web/` directory.
+
+### Automated releases (no auto-PyPI)
+On pushing a tag like `v0.2.1`, GitHub Actions will:
+- run tests against 3.10–3.12,
+- build wheels/sdist, and
+- attach artifacts to the GitHub Release (no PyPI upload).
+
+### Manual publish (when you’re ready)
+1. Create a token on PyPI (or TestPyPI).
+2. Add a repo secret:
+   - **Settings → Secrets and variables → Actions**
+   - New secrets: `PYPI_API_TOKEN` (and/or `TEST_PYPI_API_TOKEN`)
+3. From **Actions** tab, run **publish**:
+   - Choose **pypi** or **testpypi**
+   - Optionally set **ref** (leave blank to use default branch HEAD)
+4. The workflow builds and uploads the current code to the chosen index.


### PR DESCRIPTION
## Summary
- update the release workflow to build, test, and attach artifacts when tags are pushed
- add a manual publish workflow for PyPI/TestPyPI uploads
- document the automated release and manual publish processes in the README

## Testing
- not run (CI will cover)


------
https://chatgpt.com/codex/tasks/task_e_68e266a28c088333a9d44aaa886d99ed