### PR TITLE
Add Sudoku analysis API and CLI check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ sudoku-dlx dedupe --in puzzles.txt --out unique.txt
 # Generate a unique puzzle (deterministic with seed)
 sudoku-dlx gen   --seed 123 --givens 30           # ~target clue count (approx)
 sudoku-dlx gen   --seed 123 --givens 30 --pretty
+# Analyze (valid/solvable/unique/difficulty/stats/canonical)
+sudoku-dlx check --grid "<81chars>"
+sudoku-dlx check --grid "<81chars>" --json > report.json
 # Advanced generator flags:
 sudoku-dlx gen   --seed 123 --givens 28 --minimal
 sudoku-dlx gen   --seed 123 --givens 28 --symmetry rot180

--- a/src/sudoku_dlx/__init__.py
+++ b/src/sudoku_dlx/__init__.py
@@ -7,6 +7,7 @@ from .api import (
     count_solutions,
     from_string,
     is_valid,
+    analyze,
     solve,
     to_string,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "to_string",
     "is_valid",
     "solve",
+    "analyze",
     "count_solutions",
     "rate",
     "canonical_form",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,41 @@
+from textwrap import dedent
+import json
+from sudoku_dlx import analyze, from_string
+from sudoku_dlx import cli
+
+PUZ = dedent(
+    """
+    53..7....
+    6..195...
+    .98....6.
+    8...6...3
+    4..8.3..1
+    7...2...6
+    .6....28.
+    ...419..5
+    ....8..79
+    """
+).strip()
+
+def test_analyze_api_keys():
+    g = from_string(PUZ)
+    data = analyze(g)
+    for k in ["version","valid","givens","solvable","unique","difficulty","canonical","solution","stats"]:
+        assert k in data
+    st = data["stats"]
+    for k in ["ms","nodes","backtracks"]:
+        assert k in st
+
+def test_cli_check_pretty_and_json(capsys):
+    rc = cli.main(["check", "--grid", PUZ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "valid:" in out and "difficulty:" in out and "canonical:" in out
+
+    rc = cli.main(["check", "--grid", PUZ, "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    data = json.loads(out)
+    assert data["valid"] is True
+    assert "canonical" in data and len(data["canonical"]) == 81
+    assert isinstance(data["difficulty"], float)


### PR DESCRIPTION
## Summary
- add an `analyze(grid)` API that reports validation, uniqueness, difficulty, and stats
- expose a `sudoku-dlx check` CLI with pretty text and JSON output modes
- document the new command and add tests covering the API and CLI behaviour

## Testing
- pytest tests/test_check.py

------
https://chatgpt.com/codex/tasks/task_e_68e293fc46848333bdf67ae2299cb5d1