### PR TITLE
Add dataset statistics CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ sudoku-dlx gen   --seed 123 --givens 30 --pretty
 # Analyze (valid/solvable/unique/difficulty/stats/canonical)
 sudoku-dlx check --grid "<81chars>"
 sudoku-dlx check --grid "<81chars>" --json > report.json
+
+# Dataset stats
+sudoku-dlx stats-file --in puzzles.txt --json stats.json --csv diff_hist.csv
+# prints a compact JSON summary to stdout and writes optional files:
+# {
+#   "count": 1000, "valid_pct": 100.0, "solvable_pct": 100.0, "unique_pct": 100.0,
+#   "givens_mean": 29.4, "difficulty_mean": 4.2, "difficulty_p90": 6.8, ...
+# }
+
 # Advanced generator flags:
 sudoku-dlx gen   --seed 123 --givens 28 --minimal
 sudoku-dlx gen   --seed 123 --givens 28 --symmetry rot180

--- a/tests/test_stats_file.py
+++ b/tests/test_stats_file.py
@@ -1,0 +1,18 @@
+from sudoku_dlx import cli
+
+
+def test_stats_file_small(tmp_path):
+    puzzles = tmp_path / "p.txt"
+    # make a tiny set
+    grids = [
+        "53..7....6..195... .98....6.8...6...3 4..8.3..17...2...6 .6....28... .419..5....8..79".replace(
+            " ", ""
+        ),
+        "53..7....6..195... .98....6.8...6...3 4..8.3..17...2...6 .6....28... .419..5....8..79".replace(
+            " ", ""
+        ),
+    ]
+    puzzles.write_text("\n".join(grids) + "\n", encoding="utf-8")
+    # ensure it runs and prints JSON
+    rc = cli.main(["stats-file", "--in", str(puzzles)])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- add a `stats-file` CLI subcommand that aggregates dataset validity, difficulty, and timing metrics
- support optional JSON report and CSV histogram outputs for downstream analysis
- document the workflow in the README and cover it with a regression test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e298b382308333adb473a534a68e59