### PR TITLE
Add CLI bounds, JSON outputs, and sampling controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 --symmetry rot18
 sudoku-dlx rate-file --in puzzles.txt --csv ratings.csv
 python bench/bench_file.py --in puzzles.txt
 
+## Batch controls & parallel
+Generate with bounds and multiple processes:
+```bash
+sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 \
+  --min-givens 28 --max-givens 40 --parallel 8
+```
+
+JSON output for ratings & sampling in stats:
+```bash
+sudoku-dlx rate-file  --in puzzles.txt --json > scores.ndjson
+sudoku-dlx stats-file --in puzzles.txt --limit 5000 --sample 1000 --json stats.json
+```
+
 # Dedupe a file of puzzles (fast)
 sudoku-dlx dedupe --in puzzles.txt --out unique.txt
 

--- a/tests/test_batch_parallel_bounds.py
+++ b/tests/test_batch_parallel_bounds.py
@@ -1,0 +1,25 @@
+from sudoku_dlx import cli, from_string
+
+
+def _givens(s: str) -> int:
+    return sum(1 for ch in s if ch != '.')
+
+
+def test_gen_batch_bounds_parallel(tmp_path):
+    out = tmp_path / "p.txt"
+    rc = cli.main([
+        "gen-batch",
+        "--out", str(out),
+        "--count", "6",
+        "--givens", "34",
+        "--min-givens", "30",
+        "--max-givens", "40",
+        "--parallel", "2",
+        "--symmetry", "none",
+    ])
+    assert rc == 0
+    lines = [ln.strip() for ln in out.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 6
+    for s in lines:
+        g = _givens(s)
+        assert 30 <= g <= 40

--- a/tests/test_rate_file_json.py
+++ b/tests/test_rate_file_json.py
@@ -1,0 +1,17 @@
+import json
+from sudoku_dlx import cli
+
+
+def test_rate_file_json(tmp_path, capsys):
+    p = tmp_path / "p.txt"
+    grids = [
+        "53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79",
+        "53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79",
+    ]
+    p.write_text("\n".join(grids) + "\n", encoding="utf-8")
+    rc = cli.main(["rate-file", "--in", str(p), "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    j = json.loads(out[0])
+    assert "grid" in j and "score" in j

--- a/tests/test_stats_file_limit_sample.py
+++ b/tests/test_stats_file_limit_sample.py
@@ -1,0 +1,19 @@
+import json
+from sudoku_dlx import cli
+
+
+def test_stats_file_limit_and_sample(tmp_path, capsys):
+    # prepare 10 puzzles
+    out = tmp_path / "p.txt"
+    rc = cli.main(["gen-batch", "--out", str(out), "--count", "10", "--givens", "34", "--symmetry", "none"])
+    assert rc == 0
+    # limit=5
+    rc = cli.main(["stats-file", "--in", str(out), "--limit", "5"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["count"] == 5
+    # sample=4 (no limit)
+    rc = cli.main(["stats-file", "--in", str(out), "--sample", "4"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["count"] == 4


### PR DESCRIPTION
## Summary
- add CLI options for gen-batch to enforce givens bounds, run in parallel, and emit JSON ratings/stats output
- rework batch generation with a multiprocessing-safe worker and add reservoir sampling/limits to stats-file
- document the new controls in the README and cover them with targeted CLI tests

## Testing
- pytest -q
- pytest tests/test_batch_parallel_bounds.py -q
- pytest tests/test_rate_file_json.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e2c02e8e208333a5071ede3568d539