### PR TITLE
Add Hypothesis property tests and fuzz harness

### DIFF
--- a/bench/fuzz_quick.py
+++ b/bench/fuzz_quick.py
@@ -1,0 +1,33 @@
+"""
+Quick manual fuzz: generate and solve a bunch of puzzles.
+Run locally:  python bench/fuzz_quick.py --n 50
+"""
+import argparse, random
+from sudoku_dlx import generate, solve, count_solutions
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=50)
+    ap.add_argument("--givens", type=int, default=34)
+    ap.add_argument("--minimal", action="store_true")
+    ns = ap.parse_args()
+    rng = random.Random(42)
+    ok = 0
+    for i in range(ns.n):
+        g = generate(
+            seed=rng.randrange(2**31 - 1),
+            target_givens=ns.givens,
+            minimal=ns.minimal,
+            symmetry="none",
+        )
+        # must be at least uniquely solvable
+        assert count_solutions(g, limit=2) == 1
+        res = solve([row[:] for row in g])
+        assert res is not None
+        ok += 1
+    print(f"OK: {ok}/{ns.n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ sudoku-dlx = "sudoku_dlx.cli:main"
 sudoku-dlx = "sudoku_dlx.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.6", "black>=24.8", "pre-commit>=3.7"]
+dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.6", "black>=24.8", "pre-commit>=3.7", "hypothesis>=6.113"]
 
 [project.urls]
 Homepage = "https://github.com/SaridakisStamatisChristos/sudoku_dlx"

--- a/tests/test_prop_canonical_simple.py
+++ b/tests/test_prop_canonical_simple.py
@@ -1,0 +1,13 @@
+from hypothesis import given, settings, strategies as st
+from sudoku_dlx import from_string, canonical_form
+
+# Keep canonical check cheap: compare original vs rot180 isomorph
+@settings(max_examples=10, deadline=None)
+@given(st.lists(st.sampled_from(list(".123456789")), min_size=81, max_size=81))
+def test_canonical_invariant_under_rot180(xs):
+    s = "".join(xs)
+    g = from_string(s)
+    # build rot180 string
+    s2 = "".join(s[::-1])
+    g2 = from_string(s2)
+    assert canonical_form(g) == canonical_form(g2)

--- a/tests/test_prop_generate_minimal_unique.py
+++ b/tests/test_prop_generate_minimal_unique.py
@@ -1,0 +1,23 @@
+from sudoku_dlx import generate, count_solutions
+
+
+def _is_minimal_strict(g) -> bool:
+    for r in range(9):
+        for c in range(9):
+            if g[r][c] == 0:
+                continue
+            keep = g[r][c]
+            g[r][c] = 0
+            uniq = count_solutions(g, limit=2) == 1
+            g[r][c] = keep
+            if uniq:
+                return False
+    return True
+
+
+def test_generate_minimal_unique_fast_settings():
+    # modest givens to keep runtime under control in CI
+    for seed in [5, 9]:
+        p = generate(seed=seed, target_givens=36, minimal=True, symmetry="none")
+        assert count_solutions(p, limit=2) == 1
+        assert _is_minimal_strict(p)

--- a/tests/test_prop_parse.py
+++ b/tests/test_prop_parse.py
@@ -1,0 +1,32 @@
+from hypothesis import given, settings, strategies as st
+from sudoku_dlx import from_string, to_string
+
+# Allowed characters for parser (blanks + digits)
+chars = st.sampled_from(list(".0123456789"))
+
+
+@settings(max_examples=30, deadline=None)
+@given(st.lists(chars, min_size=81, max_size=81))
+def test_from_to_string_round_trip_preserves_clues(xs):
+    s = "".join(xs)
+    g = from_string(s)
+    s2 = to_string(g)
+    assert len(s2) == 81
+    # any non-blank in input stays same in output at same index
+    for i, ch in enumerate(s):
+        if ch in "123456789":
+            assert s2[i] == ch
+        else:
+            assert s2[i] == "."  # blanks normalize to '.'
+
+
+# Mix in arbitrary whitespace; parser should ignore it
+ws = st.text(alphabet=st.sampled_from(list(" \t\r\n")), min_size=0, max_size=20)
+
+
+@settings(max_examples=20, deadline=None)
+@given(st.lists(chars, min_size=81, max_size=81), ws, ws)
+def test_parser_ignores_whitespace(xs, pre, post):
+    s = pre + "".join(xs) + post
+    g = from_string(s)
+    assert len(to_string(g)) == 81

--- a/tests/test_prop_solve_idempotent.py
+++ b/tests/test_prop_solve_idempotent.py
@@ -1,0 +1,27 @@
+from sudoku_dlx import generate, solve
+
+
+def _is_full_valid(grid):
+    # rows/cols/boxes each contain digits 1..9
+    rows = [{grid[r][c] for c in range(9)} for r in range(9)]
+    cols = [{grid[r][c] for r in range(9)} for c in range(9)]
+    boxes = [
+        {grid[r + i][c + j] for i in range(3) for j in range(3)}
+        for r in (0, 3, 6)
+        for c in (0, 3, 6)
+    ]
+    expect = set(range(1, 10))
+    return all(s == expect for s in rows + cols + boxes)
+
+
+def test_solve_idempotent_and_valid_small_seedset():
+    # keep seeds small for CI speed
+    for seed in [1, 3, 7]:
+        p = generate(seed=seed, target_givens=34, minimal=False, symmetry="none")
+        res1 = solve([row[:] for row in p])
+        assert res1 is not None
+        assert _is_full_valid(res1.grid)
+        # solving a solved grid should be a no-op
+        res2 = solve([row[:] for row in res1.grid])
+        assert res2 is not None
+        assert res2.grid == res1.grid


### PR DESCRIPTION
## Summary
- add Hypothesis to the development dependency extras
- add lean property-based tests that exercise parsing, solving, generation, and canonicalization invariants
- add a quick manual fuzz harness for generating and solving random puzzles

## Testing
- pytest *(fails: ModuleNotFoundError for hypothesis in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cdfc19448333b267c2872b25d6a7