### PR TITLE
Add release gates to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,29 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U build
           python -m pip install -e ".[dev]"
+          python -m pip install -U twine
 
       - name: Run tests
         run: pytest -q
 
       - name: Build sdist and wheel
         run: python -m build
+
+      - name: Twine check
+        run: python -m twine check dist/*
+
+      - name: Version matches tag
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: python tools/version_guard.py --tag "$GITHUB_REF_NAME"
+
+      - name: Install wheel and import package
+        run: |
+          python -m pip install --force-reinstall dist/*.whl
+          python - <<'PY'
+          import sudoku_dlx as s
+          print("import ok; version:", s.__version__)
+          PY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ On pushing a tag like `v0.2.1`, GitHub Actions will:
 - build wheels/sdist, and
 - attach artifacts to the GitHub Release (no PyPI upload).
 
+**Release gates**:
+- `twine check` validates the built metadata.
+- tag `vX.Y.Z` must equal `sudoku_dlx.__version__` (build fails if not).
+- installs the wheel and imports the package before attaching.
+
 ### Manual publish (when you’re ready)
 1. Create a token on PyPI (or TestPyPI).
 2. Add a repo secret:

--- a/tools/version_guard.py
+++ b/tools/version_guard.py
@@ -1,0 +1,34 @@
+"""
+Fail the build if the Git tag (refs/tags/vX.Y.Z) does not match sudoku_dlx.__version__.
+Usage (CI): python tools/version_guard.py --tag "$GITHUB_REF_NAME"
+"""
+from __future__ import annotations
+import argparse, re, sys
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tag", required=True, help="git tag name, e.g. v0.2.1")
+    ns = ap.parse_args()
+    tag = ns.tag.strip()
+    m = re.fullmatch(r"v(\d+\.\d+\.\d+)", tag)
+    if not m:
+        print(f"[version_guard] Not a release tag: {tag}", file=sys.stderr)
+        return 2
+    tag_ver = m.group(1)
+    try:
+        import sudoku_dlx as pkg
+    except Exception as e:
+        print(f"[version_guard] Failed to import sudoku_dlx: {e}", file=sys.stderr)
+        return 3
+    code_ver = getattr(pkg, "__version__", None)
+    if code_ver is None:
+        print("[version_guard] sudoku_dlx.__version__ missing", file=sys.stderr)
+        return 4
+    if code_ver != tag_ver:
+        print(f"[version_guard] Version mismatch: tag v{tag_ver} != code {code_ver}", file=sys.stderr)
+        return 5
+    print(f"[version_guard] OK: tag v{tag_ver} == code {code_ver}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a version guard utility that compares the tag to `sudoku_dlx.__version__`
- extend the release workflow to run `twine check`, enforce the version guard, and smoke test the wheel
- document the new release gates in the README

## Testing
- `pytest -q` *(fails: missing optional dev dependency `hypothesis` in environment)*
- `python -m pip install -e ".[dev]"` *(fails: network restrictions while downloading build requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68e3817b28d88333808363ca49f37ab0