### PR TITLE
Add MkDocs documentation site and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         env:
           HYPOTHESIS_PROFILE: ci
         run: pytest -q --maxfail=1 --disable-warnings --cov=sudoku_dlx --cov-report=xml -m "not prop"
+      - name: Build docs (no deploy)
+        run: |
+          python -m pip install -U mkdocs mkdocs-material
+          mkdocs build --strict
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: docs
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install docs deps
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e ".[dev]"
+      - name: Build docs
+        run: mkdocs build --strict
+      - name: Deploy to gh-pages/docs/
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: docs
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Fast **Sudoku** solver & generator using **Algorithm X / Dancing Links (DLX)** w
 > © 2025 Stamatis-Christos Saridakis — MIT. Core algorithm: exact cover (Knuth). This implementation is original and bitset-based.
 
 [![CI](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/SaridakisStamatisChristos/sudoku_dlx/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue)](https://SaridakisStamatisChristos.github.io/sudoku_dlx/docs/)
 [![Codecov](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx/branch/main/graph/badge.svg)](https://codecov.io/gh/SaridakisStamatisChristos/sudoku_dlx)
 [![License: MIT](https://img.shields.io/github/license/SaridakisStamatisChristos/sudoku_dlx.svg)](LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/sudoku_dlx.svg)](https://pypi.org/project/sudoku_dlx/)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,61 @@
+# Python API
+
+```python
+from sudoku_dlx import (
+  from_string, to_string, is_valid, solve, analyze, rate,
+  count_solutions, generate, canonical_form, explain,
+  build_reveal_trace, sat_solve
+)
+```
+
+## Parsing
+```python
+g = from_string("53..7....6..195... ...")  # 81 chars; .,0,-,_ are blanks
+s = to_string(g)                             # always 81 chars with dots for blanks
+```
+
+## Solve
+```python
+res = solve(g)  # None if unsolvable/invalid
+res.grid        # 9x9 list of ints
+res.stats.ms, res.stats.nodes, res.stats.backtracks
+```
+
+## Analyze
+```python
+analyze(g)  # dict: {valid, solvable, unique, givens, difficulty, stats{...}}
+```
+
+## Generate
+```python
+p = generate(seed=123, target_givens=30, minimal=True, symmetry="mix")
+```
+
+## Canonical form
+```python
+can = canonical_form(g)  # 81-char canonical string (isomorphism-invariant)
+```
+
+## Difficulty
+```python
+score = rate(g)  # [0, 10], deterministic (nodes/backtracks/gaps/fill)
+```
+
+## Explain (human steps)
+```python
+exp = explain(g, max_steps=200)
+exp["steps"]     # list of {type, strategy, ...}
+exp["progress"]  # 81-char after steps
+exp["solution"]  # full solution string (if solvable)
+```
+
+## Trace (solution reveal)
+```python
+trace = build_reveal_trace(g, res.grid, res.stats)
+# keys: version, kind, initial, solution, steps, stats
+```
+
+## SAT cross-check (optional)
+```python
+sat = sat_solve(g)   # requires python-sat; returns 9x9 grid or None
+```

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,0 +1,23 @@
+# Batch & Datasets
+
+## Generate many puzzles
+```bash
+sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 \
+  --min-givens 28 --max-givens 40 --parallel 8
+```
+Puzzles are written one per line in **canonical** form, de-duplicated.
+
+## Rate a file
+```bash
+sudoku-dlx rate-file --in puzzles.txt --json > scores.ndjson
+```
+
+## Stats with sampling
+```bash
+sudoku-dlx stats-file --in puzzles.txt --limit 5000 --sample 1000 --json stats.json
+```
+
+## Dedupe a file
+```bash
+sudoku-dlx dedupe --in puzzles.txt --out unique.txt
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,10 @@
+# Changelog (highlights)
+
+## 0.1.0
+- Bitset DLX solver with stats
+- Unique/minimal generator (symmetry options)
+- Canonicalization & dedupe
+- Difficulty v2 (deterministic)
+- Explain with human strategies (singles, pairs, triples, X-Wing, Swordfish, Simple Coloring)
+- Batch tools (`gen-batch`, `rate-file`, `stats-file`, `dedupe`)
+- Trace export + visualizer (`web/visualizer.html`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,46 @@
+# CLI Guide
+
+Run `sudoku-dlx --help` for a full list.
+
+## Solve
+```bash
+sudoku-dlx solve --grid "<81chars>" [--pretty] [--stats] [--trace out.json] [--crosscheck sat]
+```
+
+## Generate
+```bash
+sudoku-dlx gen --seed 123 --givens 30 [--minimal] [--symmetry none|rot180|mix] [--pretty]
+```
+
+## Rate
+```bash
+sudoku-dlx rate --grid "<81chars>"
+```
+
+## Check (analyze)
+```bash
+sudoku-dlx check --grid "<81chars>" [--json]
+```
+
+## Canonicalize
+```bash
+sudoku-dlx canon --grid "<81chars>"
+```
+
+## Explain (human steps)
+```bash
+sudoku-dlx explain --grid "<81chars>" [--json] [--max-steps 200]
+```
+
+## Batch tools
+```bash
+# Generate unique canonical puzzles
+sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 \
+  --min-givens 28 --max-givens 40 --parallel 8
+
+# Rate file (JSON lines)
+sudoku-dlx rate-file --in puzzles.txt --json > scores.ndjson
+
+# Stats with sampling & histogram CSV
+sudoku-dlx stats-file --in puzzles.txt --limit 5000 --sample 1000 --json stats.json
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# Sudoku DLX
+
+Fast **Sudoku** solver & generator using **Algorithm X / Dancing Links** with **Python bitsets**.  
+Includes **unique/minimal** generation, **difficulty v2**, **canonicalization**, **explainable steps**, batch tools, and a JS demo.
+
+**Repo:** [:octicons-mark-github-16: GitHub](https://github.com/SaridakisStamatisChristos/sudoku_dlx) · **Docs:** this site · **Demo:** GitHub Pages `web/` and `visualizer.html`.
+
+## Features
+- Bitset DLX solver with stats (nodes, backtracks)
+- Unique/minimal generator with symmetry controls
+- Deterministic **difficulty v2** ([0,10])
+- Canonical form & dataset de-duplication
+- Human strategies: singles, pairs, triples, **X-Wing**, **Swordfish**, **Simple Coloring**
+- CLI for solve/rate/gen/canon/explain/batch
+
+## Install
+```bash
+python -m pip install sudoku_dlx  # (after PyPI publish)
+```
+For development:
+```bash
+git clone https://github.com/SaridakisStamatisChristos/sudoku_dlx
+cd sudoku_dlx
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+Optional SAT cross-check:
+```bash
+pip install -e ".[sat]"
+```
+
+## Hello Sudoku
+```python
+from sudoku_dlx import from_string, solve, to_string, explain
+g = from_string("53..7....6..195... ...")  # 81 chars; dots for blanks
+res = solve(g)
+print(to_string(res.grid))
+steps = explain(g, max_steps=200)
+print(steps["steps"][:3])  # preview moves
+```
+
+## Links
+- CLI Guide: [CLI reference](cli.md)
+- API Reference: [Python API](api.md)
+- Strategies: [Human strategies](strategies.md)
+- Batch: [Datasets & tooling](batch.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart
+
+## Solve a puzzle
+```bash
+sudoku-dlx solve --grid "<81chars>" --pretty --stats
+```
+
+## Generate
+```bash
+sudoku-dlx gen --seed 123 --givens 30 --pretty
+sudoku-dlx gen --seed 123 --givens 28 --minimal --symmetry rot180
+```
+
+## Rate
+```bash
+sudoku-dlx rate --grid "<81chars>"
+```
+
+## Analyze (valid/unique/difficulty)
+```bash
+sudoku-dlx check --grid "<81chars>" --json
+```
+
+## Explain steps
+```bash
+sudoku-dlx explain --grid "<81chars>" --json --max-steps 200
+```
+
+## Batch generate & stats
+```bash
+sudoku-dlx gen-batch --out puzzles.txt --count 1000 --givens 30 --parallel 8
+sudoku-dlx stats-file --in puzzles.txt --limit 5000 --sample 1000 --json stats.json
+```
+
+## Trace & visualization
+```bash
+sudoku-dlx solve --grid "<81chars>" --trace out.json
+# Open web/visualizer.html and load out.json
+```

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,25 @@
+# Human Strategies
+
+Deterministic ordering, **one elimination per step** for stable playback:
+
+## Placements
+- **Naked single** — only one candidate in a cell
+- **Hidden single** — the only place for a digit in a unit (row/col/box)
+
+## Eliminations
+- **Locked candidates**
+  - Pointing (box → line)
+  - Claiming (line → box)
+- **Pairs**
+  - Naked pair
+  - Hidden pair
+- **Triples**
+  - Naked triple
+  - Hidden triple
+- **Fish**
+  - X-Wing (rows/cols)
+  - Swordfish (rows/cols)
+- **Coloring**
+  - Simple coloring (Rule 2)
+
+These are implemented in `sudoku_dlx/strategies.py` and consumed by `explain()`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,48 @@
+site_name: Sudoku DLX
+site_description: Fast Sudoku DLX (Algorithm X) with generator, analysis, and explainable steps.
+site_url: https://SaridakisStamatisChristos.github.io/sudoku_dlx/docs/
+repo_url: https://github.com/SaridakisStamatisChristos/sudoku_dlx
+repo_name: SaridakisStamatisChristos/sudoku_dlx
+copyright: "© 2025 Stamatis-Christos Saridakis. MIT."
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+  icon:
+    repo: fontawesome/brands/github
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/SaridakisStamatisChristos
+  generator: false
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - CLI Guide: cli.md
+  - Python API: api.md
+  - Strategies: strategies.md
+  - Batch & Datasets: batch.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - toc:
+      permalink: true
+  - tables
+  - codehilite
+
+plugins:
+  - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ sudoku-dlx = "sudoku_dlx.cli:main"
 sudoku-dlx = "sudoku_dlx.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.6", "black>=24.8", "pre-commit>=3.7", "hypothesis>=6.113"]
+dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.6", "black>=24.8", "pre-commit>=3.7", "hypothesis>=6.113",
+       "mkdocs>=1.6", "mkdocs-material>=9.5"]
 # optional solver cross-checkers
 sat = ["python-sat>=0.1.8"]
 


### PR DESCRIPTION
## Summary
- configure MkDocs Material with a new documentation structure under `docs/`
- extend dev dependencies and CI to build the docs
- add a GitHub Pages deployment workflow and README badge linking to the hosted docs

## Testing
- ⚠️ `python -m pip install mkdocs mkdocs-material` *(fails: proxy 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e421991474833394f945477b1871a3